### PR TITLE
Fix: file descriptors in runtwo.py

### DIFF
--- a/tools/runtwo.py
+++ b/tools/runtwo.py
@@ -6,7 +6,7 @@ import subprocess
 
 r1, w1 = os.pipe()
 r2, w2 = os.pipe()
-iserv = subprocess.Popen(sys.argv[1].split(),  stdin = os.fdopen(r1), stdout = os.fdopen(w2,'w'), stderr=sys.stderr)
-sol = subprocess.Popen(sys.argv[2].split(), stdin = os.fdopen(r2), stdout = os.fdopen(w1,'w'), stderr=sys.stderr)
+iserv = subprocess.Popen(sys.argv[1].split(),  stdin = os.fdopen(r1), stdout = os.fdopen(w2,'w'), stderr=sys.stderr, close_fds=True)
+sol = subprocess.Popen(sys.argv[2].split(), stdin = os.fdopen(r2), stdout = os.fdopen(w1,'w'), stderr=sys.stderr, close_fds=True)
 sol.wait()
 iserv.wait()


### PR DESCRIPTION
The `test_solution.sh` does not work in my linux, Ubuntu 16.04. And I fixed it, so I do pull request.

The reason was:
The `runtwo.py` does not close the file descriptors between the solution program and `tools/interactor`, even after the solution program have terminated. So the interactor blocks forever and the test tools stops.

The argument `close_fds=True` for `subprocess.Popen` fixes this problem.
